### PR TITLE
HW 4. Пробуем сдать работу спредыдущего потока

### DIFF
--- a/kubernetes-volumes/minio-headless-service.yaml
+++ b/kubernetes-volumes/minio-headless-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  clusterIP: None
+  ports:
+    - port: 9000
+      name: minio
+  selector:
+    app: minio

--- a/kubernetes-volumes/minio-secret.yaml
+++ b/kubernetes-volumes/minio-secret.yaml
@@ -1,0 +1,7 @@
+kind: Secret 
+apiVersion: v1 
+metadata:
+  name: minio-secret
+stringData:
+  MINIO_ACCESS_KEY: minio
+  MINIO_SECRET_KEY: minio123

--- a/kubernetes-volumes/minio-statefulset.yaml
+++ b/kubernetes-volumes/minio-statefulset.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  # This name uniquely identifies the StatefulSet
+  name: minio
+spec:
+  serviceName: minio
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  template:
+    metadata:
+      labels:
+        app: minio # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+      - name: minio
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom: 
+            secretKeyRef:
+              name: minio-secret
+              key: MINIO_ACCESS_KEY
+        - name: MINIO_SECRET_KEY
+          valueFrom: 
+            secretKeyRef:
+              name: minio-secret
+              key: MINIO_SECRET_KEY
+        # - name: MINIO_ACCESS_KEY
+        #   value: "minio"
+        # - name: MINIO_SECRET_KEY
+        #   value: "minio123"
+        image: minio/minio:RELEASE.2019-07-10T00-34-56Z
+        args:
+        - server
+        - /data 
+        ports:
+        - containerPort: 9000
+        # These volume mounts are persistent. Each pod in the PetSet
+        # gets a volume mounted based on this field.
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        # Liveness probe detects situations where MinIO server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above.
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi


### PR DESCRIPTION
# Выполнено ДЗ № 5 (попытка сдать старую работу)

 - [*] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
1. kind
        1.1 Установка 
            https://kind.sigs.k8s.io/docs/user/quick-start#installation
        
        1.2 Создаем кластер
            kind create cluster
            export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"

        1.3 Создаем файл minio-statefulset.yaml
            https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Kuberenetes-volumes/minio-statefulset.yaml

        1.4 Создаем файл minio-headless-service.yaml
            https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Kuberenetes-volumes/minio-headless-service.yaml
        
    2. Проверка работы
        2.1 Используя команды
            kubectl get statefulsets
            kubectl get pods
            kubectl get pvc
            kubectl get pv
            kubectl describe <resource> <resource_name>

        2.2 Используя minio/mc
            https://github.com/minio/mc

## Как запустить проект:
 1.  kubectl apply -f minio-secret.yaml
 2.  kubectl apply -f minio-statefulset.yaml
 3.  kubectl apply -f minio-headless-service.yaml

## Как проверить работоспособность:
 - kubectl get statefulsets

## PR checklist:
 - [*] Выставлен label с номером домашнего задания


